### PR TITLE
fix(update): make the what's new prompt report real versions and commits

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,21 @@
 # Changelog
 
-## Unreleased
+## 0.3.0 - 2026-09-06
 
 ### Features
+- Side-by-side (split) diff layout with a global toggle.
+- Standalone markdown and HTML file preview mode.
+- Inline block comments in markdown previews, anchored to source lines, in both the diff view and the standalone preview.
 - Drag the `+` gutter button to comment on a range of lines. Ranges are sent to the agent as `Lines a-b`.
+
+### Fixes
+- The update prompt shows the commit behind each version and how many commits are new, so it can no longer read "v0.2.0 → v0.2.0" when the version number was not bumped.
+- The update prompt lists every changelog entry since the running version, and falls back to the new commits when the changelog has no entry for them.
+- A checkout that was updated but not restarted now asks for a restart instead of reporting up to date.
+- Preview comments send the agent their current line after a live reload instead of a stale one.
+- Clipboard sends stay inside the click gesture (Safari) and report a refused write instead of claiming success.
+- The block comment button in previews is reachable and clickable; reopening an open block form keeps its draft.
+- Hunk actions are preserved for deletion-only rows in split view.
 
 ## 0.2.0 - 2026-03-21
 

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ Staging gives you a dedicated, browser-based review interface with GitHub-style 
 - **Inline Comments**: Add threaded comments directly on changed lines to guide agent refinements; drag the `+` gutter button to comment on a range of lines
 - **Markdown/HTML Preview**: Toggle per-file between diff and rendered preview for `.md` and `.html` files, with inline commenting on the rendered output — hover any block for a `+` gutter button, or select text to quote it; comments carry the markdown source line so the agent knows exactly where to edit
 - **Standalone File Preview**: Point staging at a single markdown/HTML file — no git repo needed — for a live-reloading rendered preview with the same inline commenting, plus file-level comments, a general review note, and the comments panel
-- **Update Release Notes**: When a newer Staging version is available, the app opens a built-in "What's New" summary of the latest features and fixes before updating
+- **Update Release Notes**: When a newer Staging build is available, the app opens a built-in "What's New" modal showing the running and available versions (with their commits) and every changelog entry since your version before updating
 
 ## Tech Stack
 

--- a/lib/git.js
+++ b/lib/git.js
@@ -871,23 +871,11 @@ function normalizeChangelogSection(label) {
   return 'notes';
 }
 
-function parseLatestChangelogEntry(markdown) {
-  if (!markdown) return null;
-
-  const headingMatch = markdown.match(/^##\s+(.+?)\s*$/m);
-  if (!headingMatch) return null;
-
-  const title = headingMatch[1].trim();
-  const bodyStart = headingMatch.index + headingMatch[0].length;
-  const remaining = markdown.slice(bodyStart);
-  const nextHeadingMatch = remaining.match(/\n##\s+/);
-  const rawBody = nextHeadingMatch
-    ? remaining.slice(0, nextHeadingMatch.index)
-    : remaining;
-
+function parseChangelogEntry(title, rawBody) {
   const entry = {
     title,
     version: title.match(/\b\d+\.\d+\.\d+(?:-[0-9A-Za-z.-]+)?\b/)?.[0] || null,
+    date: title.match(/\b\d{4}-\d{2}-\d{2}\b/)?.[0] || null,
     features: [],
     fixes: [],
     notes: [],
@@ -913,8 +901,121 @@ function parseLatestChangelogEntry(markdown) {
   return entry;
 }
 
-function checkForUpdates(stagingRoot) {
-  const currentVersion = getLocalPackageVersion(stagingRoot);
+// Every `## <title>` section of CHANGELOG.md, in file order (newest first).
+function parseChangelogEntries(markdown) {
+  if (!markdown) return [];
+
+  return markdown
+    .split(/^##\s+/m)
+    .slice(1)
+    .map((section) => {
+      const newline = section.indexOf('\n');
+      const title = (
+        newline === -1 ? section : section.slice(0, newline)
+      ).trim();
+      const body = newline === -1 ? '' : section.slice(newline + 1);
+      return parseChangelogEntry(title, body);
+    });
+}
+
+function compareVersions(a, b) {
+  const parse = (version) =>
+    String(version)
+      .split('-')[0]
+      .split('.')
+      .map((part) => parseInt(part, 10) || 0);
+  const left = parse(a);
+  const right = parse(b);
+  for (let i = 0; i < 3; i++) {
+    const diff = (left[i] || 0) - (right[i] || 0);
+    if (diff !== 0) return diff;
+  }
+  return 0;
+}
+
+function hasChangelogItems(entry) {
+  return entry.features.length + entry.fixes.length + entry.notes.length > 0;
+}
+
+function collectChangelogItems(entries) {
+  const items = new Set();
+  for (const entry of entries) {
+    for (const item of [...entry.features, ...entry.fixes, ...entry.notes]) {
+      items.add(item);
+    }
+  }
+  return items;
+}
+
+// The remote entries a user on `currentVersion` has not seen: everything
+// above the first release at or below their version, minus the items their
+// own changelog already lists (an "Unreleased" section they already have, or
+// bullets that since moved from it under a release heading).
+function selectChangelogSince(remoteEntries, localEntries, currentVersion) {
+  const seen = collectChangelogItems(localEntries);
+  const isNew = (item) => !seen.has(item);
+  const unseen = [];
+
+  for (const entry of remoteEntries) {
+    if (
+      entry.version &&
+      currentVersion &&
+      compareVersions(entry.version, currentVersion) <= 0
+    ) {
+      break;
+    }
+    const trimmed = {
+      ...entry,
+      features: entry.features.filter(isNew),
+      fixes: entry.fixes.filter(isNew),
+      notes: entry.notes.filter(isNew),
+    };
+    if (hasChangelogItems(trimmed)) unseen.push(trimmed);
+  }
+  return unseen;
+}
+
+function gitOutput(cwd, args) {
+  return execFileSync('git', args, {
+    cwd,
+    encoding: 'utf-8',
+    maxBuffer: GIT_BUFFER_SIZE,
+  }).trim();
+}
+
+// The version and commit of the checkout at `stagingRoot` right now. The
+// server snapshots this at startup so "current" always means the code that
+// is actually running, not whatever a later pull left on disk.
+function getBuildInfo(stagingRoot) {
+  let commit = null;
+  try {
+    commit = gitOutput(stagingRoot, ['rev-parse', 'HEAD']);
+  } catch {
+    // Not a git checkout; version alone will have to do.
+  }
+  return { version: getLocalPackageVersion(stagingRoot), commit };
+}
+
+function listNewCommits(stagingRoot, range) {
+  const output = gitOutput(stagingRoot, [
+    'log',
+    '--no-merges',
+    '--format=%h%x09%s',
+    '-n',
+    '25',
+    range,
+  ]);
+  if (!output) return [];
+  return output.split('\n').map((line) => {
+    const [sha, ...subject] = line.split('\t');
+    return { sha, subject: subject.join('\t') };
+  });
+}
+
+function checkForUpdates(stagingRoot, running = getBuildInfo(stagingRoot)) {
+  const currentVersion = running.version;
+  const currentCommit = running.commit;
+  const unknown = { status: 'unknown', currentVersion, currentCommit };
 
   try {
     const fetch = spawnSync('git', ['fetch', 'origin', 'main', '--quiet'], {
@@ -922,50 +1023,72 @@ function checkForUpdates(stagingRoot) {
       encoding: 'utf-8',
       timeout: 10_000,
     });
-    if (fetch.status !== 0 || fetch.error) {
-      return { status: 'unknown', currentVersion };
-    }
+    if (fetch.status !== 0 || fetch.error) return unknown;
   } catch {
-    return { status: 'unknown', currentVersion };
+    return unknown;
   }
 
   try {
-    const head = execFileSync('git', ['rev-parse', 'HEAD'], {
-      cwd: stagingRoot,
-      encoding: 'utf-8',
-    }).trim();
-    const remote = execFileSync('git', ['rev-parse', 'origin/main'], {
-      cwd: stagingRoot,
-      encoding: 'utf-8',
-    }).trim();
+    const head = gitOutput(stagingRoot, ['rev-parse', 'HEAD']);
 
-    if (head === remote) {
+    if (currentCommit && head !== currentCommit) {
+      // The checkout moved under this process (an update was pulled but the
+      // server never restarted): what is on disk is already newer than what
+      // is running, and only a restart can apply it.
       return {
-        status: 'up-to-date',
+        status: 'restart-needed',
         currentVersion,
-        latestVersion: currentVersion,
+        currentCommit,
+        latestVersion: getLocalPackageVersion(stagingRoot),
+        latestCommit: head,
       };
     }
 
-    const remotePackageJson = getGitFileAtRef(
-      stagingRoot,
-      'origin/main',
-      'package.json',
-    );
-    const changelog = parseLatestChangelogEntry(
+    const commitsBehind =
+      parseInt(
+        gitOutput(stagingRoot, ['rev-list', '--count', 'HEAD..origin/main']),
+        10,
+      ) || 0;
+
+    if (commitsBehind === 0) {
+      return {
+        status: 'up-to-date',
+        currentVersion,
+        currentCommit,
+        latestVersion: currentVersion,
+        latestCommit: currentCommit,
+      };
+    }
+
+    const remoteEntries = parseChangelogEntries(
       getGitFileAtRef(stagingRoot, 'origin/main', 'CHANGELOG.md'),
     );
+    const localEntries = parseChangelogEntries(
+      getGitFileAtRef(stagingRoot, 'HEAD', 'CHANGELOG.md'),
+    );
     const latestVersion =
-      readPackageVersion(remotePackageJson) || changelog?.version || null;
+      readPackageVersion(
+        getGitFileAtRef(stagingRoot, 'origin/main', 'package.json'),
+      ) ||
+      remoteEntries.find((entry) => entry.version)?.version ||
+      null;
 
     return {
       status: 'update-available',
       currentVersion,
+      currentCommit,
       latestVersion,
-      changelog,
+      latestCommit: gitOutput(stagingRoot, ['rev-parse', 'origin/main']),
+      commitsBehind,
+      changelogEntries: selectChangelogSince(
+        remoteEntries,
+        localEntries,
+        currentVersion,
+      ),
+      commits: listNewCommits(stagingRoot, 'HEAD..origin/main'),
     };
   } catch {
-    return { status: 'unknown', currentVersion };
+    return unknown;
   }
 }
 
@@ -1055,6 +1178,7 @@ export {
   writeWorkingTreeFile,
   getRemoteUrl,
   pushChanges,
+  getBuildInfo,
   checkForUpdates,
   performUpdate,
 };

--- a/lib/git.js
+++ b/lib/git.js
@@ -919,22 +919,41 @@ function parseChangelogEntries(markdown) {
 }
 
 function compareVersions(a, b) {
-  const parse = (version) =>
-    String(version)
-      .split('-')[0]
-      .split('.')
-      .map((part) => parseInt(part, 10) || 0);
+  const parse = (version) => {
+    const [base, ...prerelease] = String(version).split('-');
+    return {
+      parts: base.split('.').map((part) => parseInt(part, 10) || 0),
+      prerelease: prerelease.join('-'),
+    };
+  };
   const left = parse(a);
   const right = parse(b);
   for (let i = 0; i < 3; i++) {
-    const diff = (left[i] || 0) - (right[i] || 0);
+    const diff = (left.parts[i] || 0) - (right.parts[i] || 0);
     if (diff !== 0) return diff;
   }
-  return 0;
+  // A release outranks any prerelease of the same version.
+  if (left.prerelease === right.prerelease) return 0;
+  if (!left.prerelease) return 1;
+  if (!right.prerelease) return -1;
+  return left.prerelease.localeCompare(right.prerelease, undefined, {
+    numeric: true,
+  });
 }
 
 function hasChangelogItems(entry) {
   return entry.features.length + entry.fixes.length + entry.notes.length > 0;
+}
+
+// The entries above the first release at or below `currentVersion`: the part
+// of a changelog a user on that version has not necessarily seen.
+function entriesAbove(entries, currentVersion) {
+  if (!currentVersion) return entries;
+  const cutoff = entries.findIndex(
+    (entry) =>
+      entry.version && compareVersions(entry.version, currentVersion) <= 0,
+  );
+  return cutoff === -1 ? entries : entries.slice(0, cutoff);
 }
 
 function collectChangelogItems(entries) {
@@ -947,64 +966,72 @@ function collectChangelogItems(entries) {
   return items;
 }
 
-// The remote entries a user on `currentVersion` has not seen: everything
-// above the first release at or below their version, minus the items their
-// own changelog already lists (an "Unreleased" section they already have, or
-// bullets that since moved from it under a release heading).
+// The remote entries a user on `currentVersion` has not seen, minus the items
+// their own changelog already lists above the same cutoff (an "Unreleased"
+// section they already have, or bullets that since moved from it under a
+// release heading).
 function selectChangelogSince(remoteEntries, localEntries, currentVersion) {
-  const seen = collectChangelogItems(localEntries);
+  const seen = collectChangelogItems(
+    entriesAbove(localEntries, currentVersion),
+  );
   const isNew = (item) => !seen.has(item);
-  const unseen = [];
 
-  for (const entry of remoteEntries) {
-    if (
-      entry.version &&
-      currentVersion &&
-      compareVersions(entry.version, currentVersion) <= 0
-    ) {
-      break;
-    }
-    const trimmed = {
+  return entriesAbove(remoteEntries, currentVersion)
+    .map((entry) => ({
       ...entry,
       features: entry.features.filter(isNew),
       fixes: entry.fixes.filter(isNew),
       notes: entry.notes.filter(isNew),
-    };
-    if (hasChangelogItems(trimmed)) unseen.push(trimmed);
-  }
-  return unseen;
-}
-
-function gitOutput(cwd, args) {
-  return execFileSync('git', args, {
-    cwd,
-    encoding: 'utf-8',
-    maxBuffer: GIT_BUFFER_SIZE,
-  }).trim();
+    }))
+    .filter(hasChangelogItems);
 }
 
 // The version and commit of the checkout at `stagingRoot` right now. The
 // server snapshots this at startup so "current" always means the code that
 // is actually running, not whatever a later pull left on disk.
 function getBuildInfo(stagingRoot) {
-  let commit = null;
+  const version = getLocalPackageVersion(stagingRoot);
   try {
-    commit = gitOutput(stagingRoot, ['rev-parse', 'HEAD']);
+    const toplevel = runGit(stagingRoot, ['rev-parse', '--show-toplevel']);
+    if (fs.realpathSync(toplevel.trim()) !== fs.realpathSync(stagingRoot)) {
+      // Not a checkout of Staging itself (say, installed inside another
+      // project's repo): git would be answering for the enclosing project,
+      // and there is nothing here to self-update.
+      return { version, commit: null };
+    }
+    return {
+      version,
+      commit: runGit(stagingRoot, ['rev-parse', 'HEAD']).trim(),
+    };
   } catch {
-    // Not a git checkout; version alone will have to do.
+    return { version, commit: null };
   }
-  return { version: getLocalPackageVersion(stagingRoot), commit };
+}
+
+function isAncestor(stagingRoot, commit, ref) {
+  const result = spawnSync(
+    'git',
+    ['merge-base', '--is-ancestor', commit, ref],
+    { cwd: stagingRoot, encoding: 'utf-8' },
+  );
+  return result.status === 0;
+}
+
+function countCommits(stagingRoot, args) {
+  return (
+    parseInt(runGit(stagingRoot, ['rev-list', '--count', ...args]), 10) || 0
+  );
 }
 
 function listNewCommits(stagingRoot, range) {
-  const output = gitOutput(stagingRoot, [
+  const output = runGit(stagingRoot, [
     'log',
     '--no-merges',
     '--format=%h%x09%s',
     '-n',
     '25',
     range,
-  ]);
+  ]).trim();
   if (!output) return [];
   return output.split('\n').map((line) => {
     const [sha, ...subject] = line.split('\t');
@@ -1016,6 +1043,29 @@ function checkForUpdates(stagingRoot, running = getBuildInfo(stagingRoot)) {
   const currentVersion = running.version;
   const currentCommit = running.commit;
   const unknown = { status: 'unknown', currentVersion, currentCommit };
+  if (!currentCommit) return unknown;
+
+  // Needs no network: a checkout that moved onto published history under
+  // this process (an update was pulled but the server never restarted) has
+  // newer code on disk than is running, and only a restart can apply it.
+  // Local work committed on top of the running build is not that.
+  try {
+    const head = runGit(stagingRoot, ['rev-parse', 'HEAD']).trim();
+    if (
+      head !== currentCommit &&
+      isAncestor(stagingRoot, head, 'origin/main')
+    ) {
+      return {
+        status: 'restart-needed',
+        currentVersion,
+        currentCommit,
+        latestVersion: getLocalPackageVersion(stagingRoot),
+        latestCommit: head,
+      };
+    }
+  } catch {
+    return unknown;
+  }
 
   try {
     const fetch = spawnSync('git', ['fetch', 'origin', 'main', '--quiet'], {
@@ -1029,28 +1079,7 @@ function checkForUpdates(stagingRoot, running = getBuildInfo(stagingRoot)) {
   }
 
   try {
-    const head = gitOutput(stagingRoot, ['rev-parse', 'HEAD']);
-
-    if (currentCommit && head !== currentCommit) {
-      // The checkout moved under this process (an update was pulled but the
-      // server never restarted): what is on disk is already newer than what
-      // is running, and only a restart can apply it.
-      return {
-        status: 'restart-needed',
-        currentVersion,
-        currentCommit,
-        latestVersion: getLocalPackageVersion(stagingRoot),
-        latestCommit: head,
-      };
-    }
-
-    const commitsBehind =
-      parseInt(
-        gitOutput(stagingRoot, ['rev-list', '--count', 'HEAD..origin/main']),
-        10,
-      ) || 0;
-
-    if (commitsBehind === 0) {
+    if (countCommits(stagingRoot, ['HEAD..origin/main']) === 0) {
       return {
         status: 'up-to-date',
         currentVersion,
@@ -1078,8 +1107,12 @@ function checkForUpdates(stagingRoot, running = getBuildInfo(stagingRoot)) {
       currentVersion,
       currentCommit,
       latestVersion,
-      latestCommit: gitOutput(stagingRoot, ['rev-parse', 'origin/main']),
-      commitsBehind,
+      latestCommit: runGit(stagingRoot, ['rev-parse', 'origin/main']).trim(),
+      // Counted the same way the list below is built, so the two agree.
+      commitsBehind: countCommits(stagingRoot, [
+        '--no-merges',
+        'HEAD..origin/main',
+      ]),
       changelogEntries: selectChangelogSince(
         remoteEntries,
         localEntries,

--- a/lib/server.js
+++ b/lib/server.js
@@ -30,6 +30,7 @@ import {
   writeWorkingTreeFile,
   getRemoteUrl,
   pushChanges,
+  getBuildInfo,
   checkForUpdates,
   performUpdate,
 } from './git.js';
@@ -531,10 +532,14 @@ export function startServer({
   });
 
   const stagingRoot = path.join(__dirname, '..');
+  // The build this process started from. Update checks compare against it so
+  // "current" is the code the user is running, even after a pull that has
+  // not been restarted into yet.
+  const runningBuild = getBuildInfo(stagingRoot);
 
   app.get('/api/update-check', (c) => {
     try {
-      const result = checkForUpdates(stagingRoot);
+      const result = checkForUpdates(stagingRoot, runningBuild);
       return c.json(result);
     } catch (err) {
       return c.json({ status: 'unknown', error: err.message }, 500);

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "staging",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "staging",
-      "version": "0.2.0",
+      "version": "0.3.0",
       "license": "MIT",
       "dependencies": {
         "@hono/node-server": "^1.19.9",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "staging",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "description": "Stop committing blindly. Review staged changes in a rich browser UI and send inline feedback directly to your coding agent.",
   "bin": {
     "staging": "./bin/staging.js"

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -216,6 +216,8 @@ export default function App() {
         if (data.status === 'update-available') {
           setUpdateStatus(data);
           setShowWhatsNewModal(true);
+        } else if (data.status === 'restart-needed') {
+          setUpdateStatus(data);
         }
       } catch {
         // Silently ignore

--- a/src/components/WhatsNewModal.jsx
+++ b/src/components/WhatsNewModal.jsx
@@ -1,8 +1,24 @@
 import { useRef } from 'react';
 import { useModalAccessibility } from '../hooks/useModalAccessibility';
 
-function formatVersion(version, fallbackLabel = 'latest') {
+function formatVersion(version, fallbackLabel) {
   return version ? `v${version}` : fallbackLabel;
+}
+
+function VersionPill({ label, version, commit, fallbackLabel }) {
+  return (
+    <span className="whats-new-version-pill">
+      {label} {formatVersion(version, fallbackLabel)}
+      {commit && (
+        <span className="whats-new-version-commit">{commit.slice(0, 7)}</span>
+      )}
+    </span>
+  );
+}
+
+function entryHeading(entry) {
+  const name = entry.version ? `v${entry.version}` : entry.title;
+  return entry.date ? `${name} · ${entry.date}` : name;
 }
 
 function renderSection(title, items) {
@@ -20,13 +36,51 @@ function renderSection(title, items) {
   );
 }
 
+function renderEntries(entries, latestVersion) {
+  return entries.map((entry, index) => {
+    // The modal title already names the version being installed; repeat a
+    // heading only when the entry is something else (older, or unreleased).
+    const showHeading =
+      entries.length > 1 || !entry.version || entry.version !== latestVersion;
+    return (
+      <div className="whats-new-entry" key={`${entry.title}-${index}`}>
+        {showHeading && (
+          <h4 className="whats-new-entry-title">{entryHeading(entry)}</h4>
+        )}
+        {renderSection('Features', entry.features)}
+        {renderSection('Fixes', entry.fixes)}
+        {renderSection('Notes', entry.notes)}
+      </div>
+    );
+  });
+}
+
+function renderCommits(commits) {
+  return (
+    <section className="whats-new-section">
+      <h4>Commits</h4>
+      <ul className="whats-new-list">
+        {commits.map((commit) => (
+          <li key={commit.sha}>
+            <span className="whats-new-commit-sha">{commit.sha}</span>
+            {commit.subject}
+          </li>
+        ))}
+      </ul>
+    </section>
+  );
+}
+
 export default function WhatsNewModal({ updateStatus, onClose, onUpdate }) {
   const modalRef = useRef(null);
   const updateButtonRef = useRef(null);
-  const latestVersion =
-    updateStatus?.latestVersion || updateStatus?.changelog?.version || '';
   const currentVersion = updateStatus?.currentVersion || '';
-  const changelog = updateStatus?.changelog;
+  const latestVersion = updateStatus?.latestVersion || '';
+  const entries = updateStatus?.changelogEntries || [];
+  const commits = updateStatus?.commits || [];
+  const commitsBehind = updateStatus?.commitsBehind || 0;
+  const sameVersion =
+    Boolean(currentVersion) && currentVersion === latestVersion;
   const isUpdating = updateStatus?.status === 'updating';
   const titleId = 'whats-new-modal-title';
 
@@ -40,6 +94,24 @@ export default function WhatsNewModal({ updateStatus, onClose, onUpdate }) {
     if (e.target === e.currentTarget) onClose();
   }
 
+  let body;
+  if (entries.length > 0) {
+    body = (
+      <div className="whats-new-sections">
+        {renderEntries(entries, latestVersion)}
+      </div>
+    );
+  } else if (commits.length > 0) {
+    body = <div className="whats-new-sections">{renderCommits(commits)}</div>;
+  } else {
+    body = (
+      <p className="whats-new-empty">
+        Release notes were not found for this update, but a newer build is
+        available.
+      </p>
+    );
+  }
+
   return (
     <div className="modal-overlay" onClick={handleOverlayClick}>
       <div
@@ -51,39 +123,42 @@ export default function WhatsNewModal({ updateStatus, onClose, onUpdate }) {
         tabIndex={-1}
       >
         <h3 id={titleId}>
-          {latestVersion
+          {latestVersion && !sameVersion
             ? `What's New in ${formatVersion(latestVersion)}`
             : "What's New"}
         </h3>
 
         <p className="whats-new-subtitle">
-          A newer Staging build is available.
+          {sameVersion
+            ? `A newer build of v${currentVersion} is available. Its version number has not changed.`
+            : 'A newer Staging build is available.'}
         </p>
 
         <div className="whats-new-version-row" aria-label="Version details">
-          <span className="whats-new-version-pill">
-            Current {formatVersion(currentVersion, 'unknown')}
-          </span>
+          <VersionPill
+            label="Current"
+            version={currentVersion}
+            commit={updateStatus?.currentCommit}
+            fallbackLabel="unknown"
+          />
           <span className="whats-new-version-arrow" aria-hidden="true">
             →
           </span>
-          <span className="whats-new-version-pill">
-            Available {formatVersion(latestVersion, 'latest')}
-          </span>
+          <VersionPill
+            label="Available"
+            version={latestVersion}
+            commit={updateStatus?.latestCommit}
+            fallbackLabel="latest"
+          />
+          {commitsBehind > 0 && (
+            <span className="whats-new-version-meta">
+              {commitsBehind} new {commitsBehind === 1 ? 'commit' : 'commits'}{' '}
+              on origin/main
+            </span>
+          )}
         </div>
 
-        {changelog ? (
-          <div className="whats-new-sections">
-            {renderSection('Features', changelog.features)}
-            {renderSection('Fixes', changelog.fixes)}
-            {renderSection('Notes', changelog.notes)}
-          </div>
-        ) : (
-          <p className="whats-new-empty">
-            Release notes were not found for this update, but a newer version is
-            available.
-          </p>
-        )}
+        {body}
 
         <div className="modal-actions">
           <button className="btn" type="button" onClick={onClose}>

--- a/src/components/WhatsNewModal.jsx
+++ b/src/components/WhatsNewModal.jsx
@@ -55,7 +55,8 @@ function renderEntries(entries, latestVersion) {
   });
 }
 
-function renderCommits(commits) {
+function renderCommits(commits, commitsBehind) {
+  const omitted = commitsBehind - commits.length;
   return (
     <section className="whats-new-section">
       <h4>Commits</h4>
@@ -66,6 +67,9 @@ function renderCommits(commits) {
             {commit.subject}
           </li>
         ))}
+        {omitted > 0 && (
+          <li className="whats-new-commit-more">and {omitted} more</li>
+        )}
       </ul>
     </section>
   );
@@ -102,7 +106,11 @@ export default function WhatsNewModal({ updateStatus, onClose, onUpdate }) {
       </div>
     );
   } else if (commits.length > 0) {
-    body = <div className="whats-new-sections">{renderCommits(commits)}</div>;
+    body = (
+      <div className="whats-new-sections">
+        {renderCommits(commits, commitsBehind)}
+      </div>
+    );
   } else {
     body = (
       <p className="whats-new-empty">

--- a/src/style.css
+++ b/src/style.css
@@ -3578,6 +3578,11 @@ body {
   color: var(--text-3);
 }
 
+.whats-new-commit-more {
+  color: var(--text-3);
+  list-style: none;
+}
+
 .whats-new-sections {
   display: flex;
   flex-direction: column;

--- a/src/style.css
+++ b/src/style.css
@@ -3541,9 +3541,41 @@ body {
   font-size: 12px;
 }
 
+.whats-new-version-commit {
+  margin-left: 8px;
+  padding-left: 8px;
+  border-left: 1px solid var(--border-1);
+  color: var(--text-3);
+}
+
 .whats-new-version-arrow {
   color: var(--text-3);
   font-size: 14px;
+}
+
+.whats-new-version-meta {
+  color: var(--text-3);
+  font-size: 12px;
+}
+
+.whats-new-entry {
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+}
+
+.whats-new-entry-title {
+  margin: 0;
+  font-family: var(--font-mono);
+  font-size: 12px;
+  font-weight: 600;
+  color: var(--text-2);
+}
+
+.whats-new-commit-sha {
+  margin-right: 8px;
+  font-family: var(--font-mono);
+  color: var(--text-3);
 }
 
 .whats-new-sections {
@@ -3912,11 +3944,17 @@ body.is-resizing-sidebar * {
   margin-left: calc(-1 * var(--preview-gutter));
 }
 
-.preview-content > .preview-block:first-child .preview-block-body > *:first-child {
+.preview-content
+  > .preview-block:first-child
+  .preview-block-body
+  > *:first-child {
   margin-top: 0;
 }
 
-.preview-content > .preview-block:last-child .preview-block-body > *:last-child {
+.preview-content
+  > .preview-block:last-child
+  .preview-block-body
+  > *:last-child {
   margin-bottom: 0;
 }
 

--- a/tests/update-check-verify.js
+++ b/tests/update-check-verify.js
@@ -50,6 +50,9 @@ const released = [
   '### Features',
   '- Initial release.',
   '',
+  '### Notes',
+  '- Dependency updates.',
+  '',
 ].join('\n');
 const changelog = (...sections) =>
   ['# Changelog', '', ...sections, released].join('\n');
@@ -58,6 +61,8 @@ const unreleasedRange = '## Unreleased\n\n### Features\n- Range comments.\n';
 const release030 =
   '## 0.3.0 - 2026-09-06\n\n### Features\n- Range comments.\n\n### Fixes\n- Accurate update prompt.\n';
 const unreleasedSmall = '## Unreleased\n\n### Fixes\n- Something small.\n';
+const release040 =
+  '## 0.4.0 - 2026-10-01\n\n### Notes\n- Dependency updates.\n';
 
 function upstreamAt(sha) {
   git(upstream, 'reset', '-q', '--hard', sha);
@@ -88,6 +93,17 @@ try {
   const D = commit(upstream, 'fix: something small');
   write(upstream, { 'lib.js': 'x\n' });
   const E = commit(upstream, 'chore: no changelog touch');
+  write(upstream, {
+    'package.json': pkg('0.4.0'),
+    'CHANGELOG.md': changelog(release040, release030),
+  });
+  const F = commit(upstream, 'release 0.4.0');
+  git(upstream, 'checkout', '-q', '-b', 'side');
+  write(upstream, { 'side.js': 'y\n' });
+  const sideCommit = commit(upstream, 'feat: side work');
+  git(upstream, 'checkout', '-q', 'main');
+  git(upstream, 'merge', '-q', '--no-ff', '-m', 'Merge branch side', 'side');
+  const G = git(upstream, 'rev-parse', 'HEAD');
 
   git(root, 'clone', '-q', upstream, clone);
   cloneAt(A);
@@ -182,6 +198,67 @@ try {
   result = checkForUpdates(clone, { version: null, commit: A });
   assert.equal(result.currentVersion, null);
   assert.deepEqual(titles(result), ['Unreleased', '0.3.0 - 2026-09-06']);
+
+  console.log('10. commits made on top of the running build are not a restart');
+  cloneAt(E);
+  upstreamAt(E);
+  const runningE = getBuildInfo(clone);
+  write(clone, { 'local2.txt': 'z\n' });
+  commit(clone, 'more local work');
+  result = checkForUpdates(clone, runningE);
+  assert.equal(result.status, 'up-to-date');
+  cloneAt(E);
+
+  console.log('11. restart-needed is reported even when origin is unreachable');
+  cloneAt(A);
+  const runningA = getBuildInfo(clone);
+  git(clone, 'pull', '-q', 'origin', 'main');
+  git(clone, 'remote', 'set-url', 'origin', path.join(root, 'missing'));
+  result = checkForUpdates(clone, runningA);
+  assert.equal(result.status, 'restart-needed');
+  assert.equal(result.latestCommit, E);
+  result = checkForUpdates(clone);
+  assert.equal(result.status, 'unknown');
+  git(clone, 'remote', 'set-url', 'origin', upstream);
+
+  console.log('12. a release outranks a prerelease of the same version');
+  cloneAt(B);
+  upstreamAt(C);
+  result = checkForUpdates(clone, { version: '0.3.0-beta.1', commit: B });
+  assert.deepEqual(
+    result.changelogEntries.map((entry) => [entry.title, entry.fixes]),
+    [['0.3.0 - 2026-09-06', ['Accurate update prompt.']]],
+  );
+
+  console.log('13. a bullet repeated from an old release is still new');
+  cloneAt(C);
+  upstreamAt(F);
+  result = checkForUpdates(clone);
+  assert.equal(result.latestVersion, '0.4.0');
+  assert.deepEqual(
+    result.changelogEntries.map((entry) => [entry.title, entry.notes]),
+    [['0.4.0 - 2026-10-01', ['Dependency updates.']]],
+  );
+
+  console.log('14. the commit count matches the commit list (no merges)');
+  cloneAt(F);
+  upstreamAt(G);
+  result = checkForUpdates(clone);
+  assert.equal(result.status, 'update-available');
+  assert.equal(result.latestCommit, G);
+  assert.equal(result.commitsBehind, 1);
+  assert.deepEqual(result.commits, [
+    { sha: sideCommit.slice(0, 7), subject: 'feat: side work' },
+  ]);
+
+  console.log('15. a package nested inside another repo is not self-updatable');
+  const nested = path.join(clone, 'vendor', 'staging');
+  fs.mkdirSync(nested, { recursive: true });
+  write(nested, { 'package.json': pkg('9.9.9') });
+  assert.deepEqual(getBuildInfo(nested), { version: '9.9.9', commit: null });
+  result = checkForUpdates(nested);
+  assert.equal(result.status, 'unknown');
+  assert.equal(result.currentVersion, '9.9.9');
 
   console.log('\nAll update-check scenarios passed.');
 } finally {

--- a/tests/update-check-verify.js
+++ b/tests/update-check-verify.js
@@ -1,0 +1,189 @@
+// Scenario test for the update check behind the "What's New" prompt.
+// Builds a throwaway upstream repo and a clone of it, then walks the clone
+// through the situations the prompt has to describe accurately.
+// Run with: node tests/update-check-verify.js
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { spawnSync } from 'node:child_process';
+import { checkForUpdates, getBuildInfo } from '../lib/git.js';
+
+const root = fs.mkdtempSync(path.join(os.tmpdir(), 'staging-update-check-'));
+const upstream = path.join(root, 'upstream');
+const clone = path.join(root, 'clone');
+fs.mkdirSync(upstream);
+
+function git(cwd, ...args) {
+  const result = spawnSync(
+    'git',
+    ['-c', 'user.name=test', '-c', 'user.email=test@example.com', ...args],
+    { cwd, encoding: 'utf-8' },
+  );
+  if (result.status !== 0) {
+    throw new Error(`git ${args.join(' ')} failed:\n${result.stderr}`);
+  }
+  return result.stdout.trim();
+}
+
+function write(cwd, files) {
+  for (const [name, content] of Object.entries(files)) {
+    fs.writeFileSync(path.join(cwd, name), content);
+  }
+}
+
+function commit(cwd, message) {
+  git(cwd, 'add', '-A');
+  git(cwd, 'commit', '-q', '-m', message);
+  return git(cwd, 'rev-parse', 'HEAD');
+}
+
+const pkg = (version) => `${JSON.stringify({ name: 'staging', version })}\n`;
+const released = [
+  '## 0.2.0 - 2026-03-21',
+  '',
+  '### Features',
+  "- What's New modal.",
+  '',
+  '## 0.1.0 - 2026-03-20',
+  '',
+  '### Features',
+  '- Initial release.',
+  '',
+].join('\n');
+const changelog = (...sections) =>
+  ['# Changelog', '', ...sections, released].join('\n');
+
+const unreleasedRange = '## Unreleased\n\n### Features\n- Range comments.\n';
+const release030 =
+  '## 0.3.0 - 2026-09-06\n\n### Features\n- Range comments.\n\n### Fixes\n- Accurate update prompt.\n';
+const unreleasedSmall = '## Unreleased\n\n### Fixes\n- Something small.\n';
+
+function upstreamAt(sha) {
+  git(upstream, 'reset', '-q', '--hard', sha);
+}
+
+function cloneAt(sha) {
+  git(clone, 'reset', '-q', '--hard', sha);
+}
+
+const titles = (result) => result.changelogEntries.map((entry) => entry.title);
+const subjects = (result) => result.commits.map((entry) => entry.subject);
+
+try {
+  git(upstream, 'init', '-q', '-b', 'main');
+  write(upstream, {
+    'package.json': pkg('0.2.0'),
+    'CHANGELOG.md': changelog(),
+  });
+  const A = commit(upstream, 'release 0.2.0');
+  write(upstream, { 'CHANGELOG.md': changelog(unreleasedRange) });
+  const B = commit(upstream, 'feat: range comments');
+  write(upstream, {
+    'package.json': pkg('0.3.0'),
+    'CHANGELOG.md': changelog(release030),
+  });
+  const C = commit(upstream, 'release 0.3.0');
+  write(upstream, { 'CHANGELOG.md': changelog(unreleasedSmall, release030) });
+  const D = commit(upstream, 'fix: something small');
+  write(upstream, { 'lib.js': 'x\n' });
+  const E = commit(upstream, 'chore: no changelog touch');
+
+  git(root, 'clone', '-q', upstream, clone);
+  cloneAt(A);
+
+  console.log('1. same version number, new commits with unreleased notes');
+  upstreamAt(B);
+  let result = checkForUpdates(clone);
+  assert.equal(result.status, 'update-available');
+  assert.equal(result.currentVersion, '0.2.0');
+  assert.equal(result.latestVersion, '0.2.0');
+  assert.equal(result.currentCommit, A);
+  assert.equal(result.latestCommit, B);
+  assert.equal(result.commitsBehind, 1);
+  assert.deepEqual(titles(result), ['Unreleased']);
+  assert.deepEqual(result.changelogEntries[0].features, ['Range comments.']);
+  assert.deepEqual(subjects(result), ['feat: range comments']);
+
+  console.log('2. bumped version: only entries newer than the current one');
+  upstreamAt(C);
+  result = checkForUpdates(clone);
+  assert.equal(result.latestVersion, '0.3.0');
+  assert.equal(result.latestCommit, C);
+  assert.equal(result.commitsBehind, 2);
+  assert.deepEqual(
+    result.changelogEntries.map((entry) => [
+      entry.title,
+      entry.version,
+      entry.date,
+    ]),
+    [['0.3.0 - 2026-09-06', '0.3.0', '2026-09-06']],
+  );
+  assert.deepEqual(result.changelogEntries[0].fixes, [
+    'Accurate update prompt.',
+  ]);
+
+  console.log('3. bullets already in the local changelog are not repeated');
+  cloneAt(B);
+  result = checkForUpdates(clone);
+  assert.equal(result.commitsBehind, 1);
+  assert.deepEqual(
+    result.changelogEntries.map((entry) => [
+      entry.title,
+      entry.features,
+      entry.fixes,
+    ]),
+    [['0.3.0 - 2026-09-06', [], ['Accurate update prompt.']]],
+  );
+
+  console.log('4. unreleased section above a newer release: both listed');
+  cloneAt(A);
+  upstreamAt(D);
+  result = checkForUpdates(clone);
+  assert.deepEqual(titles(result), ['Unreleased', '0.3.0 - 2026-09-06']);
+  assert.equal(result.commitsBehind, 3);
+
+  console.log('5. changelog untouched by the new commits: commit list instead');
+  cloneAt(D);
+  upstreamAt(E);
+  result = checkForUpdates(clone);
+  assert.equal(result.status, 'update-available');
+  assert.equal(result.currentVersion, '0.3.0');
+  assert.equal(result.latestVersion, '0.3.0');
+  assert.deepEqual(result.changelogEntries, []);
+  assert.deepEqual(subjects(result), ['chore: no changelog touch']);
+
+  console.log('6. pulled but not restarted: restart-needed, not up-to-date');
+  cloneAt(A);
+  const running = getBuildInfo(clone);
+  assert.deepEqual(running, { version: '0.2.0', commit: A });
+  git(clone, 'pull', '-q', 'origin', 'main');
+  result = checkForUpdates(clone, running);
+  assert.equal(result.status, 'restart-needed');
+  assert.equal(result.currentVersion, '0.2.0');
+  assert.equal(result.latestVersion, '0.3.0');
+  assert.equal(result.currentCommit, A);
+  assert.equal(result.latestCommit, E);
+
+  console.log('7. same commit as origin/main: up-to-date');
+  result = checkForUpdates(clone);
+  assert.equal(result.status, 'up-to-date');
+  assert.equal(result.latestVersion, '0.3.0');
+  assert.equal(result.currentCommit, E);
+
+  console.log('8. local commits ahead of origin/main are not an update');
+  write(clone, { 'local.txt': 'y\n' });
+  commit(clone, 'local work');
+  result = checkForUpdates(clone);
+  assert.equal(result.status, 'up-to-date');
+
+  console.log('9. unknown local version: still only unseen bullets');
+  cloneAt(A);
+  result = checkForUpdates(clone, { version: null, commit: A });
+  assert.equal(result.currentVersion, null);
+  assert.deepEqual(titles(result), ['Unreleased', '0.3.0 - 2026-09-06']);
+
+  console.log('\nAll update-check scenarios passed.');
+} finally {
+  fs.rmSync(root, { recursive: true, force: true });
+}


### PR DESCRIPTION
## Why

Updates are "pull origin/main", so every merge is a release, but `package.json` has said 0.2.0 since March while split view, standalone preview, block comments and range comments all shipped. The "What's New" prompt therefore read **Current v0.2.0 → Available v0.2.0** for six months of updates and titled itself after a version the user already had.

## What changes

**Prompt accuracy**
- Both version pills carry the commit they were built from, plus a "N new commits on origin/main" line, so two builds of the same version are always told apart.
- The modal lists every changelog entry newer than the running version, minus bullets the local changelog already lists above the same cutoff. When the changelog has nothing for the new commits, it lists the commits instead (capped, with an "and N more" note).
- The title only says "What's New in vX" when X differs from the running version.

**Update-check correctness**
- The server snapshots the build it started from, so "current" is the code actually running.
- A checkout that was pulled onto published history but never restarted reports `restart-needed` (checked before the network fetch, so it works offline). Local commits on top of the running build do not trigger it.
- A local branch ahead of origin/main is no longer offered an update.
- A package that is not the top of its own git checkout is never self-updated (git would otherwise answer for the enclosing project).
- A release outranks a prerelease of the same version.

**Release**
- Bump to 0.3.0 and stamp the changelog with everything shipped since 0.2.0.

## Verification

- `node tests/update-check-verify.js`: 15 scenarios against a throwaway upstream/clone pair, no dependencies needed. All pass.
- JSX parses under `tsc`; core ESLint rules and Prettier 3.8.1 pass on every changed file.
- The repo's own `npm run lint` and `npm run build` could not run in the authoring environment (npm registry blocked). Run them locally before relying on the build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019AnGvRoSMRomh2avs9KSur

---
_Generated by [Claude Code](https://claude.ai/code/session_019AnGvRoSMRomh2avs9KSur)_